### PR TITLE
Ignore some JS in coverage as long as Jest is not supporting ES modules

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,10 @@
 module.exports = {
   collectCoverage: true,
-  collectCoverageFrom: ["packages/**/*.{js}", "!**/node_modules/**"],
+  collectCoverageFrom: [
+    "packages/**/*.{js}",
+    "!**/node_modules/**",
+    "!**/*.config.js",
+    "!**/server-web/src/client/**/*.js"
+  ],
   roots: ["packages/", "tests/"]
 };


### PR DESCRIPTION
This may fix some issues with coverage. We should follow [Jest issue #4842](https://github.com/facebook/jest/issues/4842) to find out when ES modules are supported.