### PR TITLE
Provide events that change a todo

### DIFF
--- a/packages/storage-events/src/__snapshots__/replay.spec.js.snap
+++ b/packages/storage-events/src/__snapshots__/replay.spec.js.snap
@@ -71,3 +71,49 @@ Array [
   },
 ]
 `;
+
+exports[`replay editing todos EDIT_TODO can edit child todos 1`] = `
+Array [
+  Object {
+    "children": Array [
+      Object {
+        "id": "id-2",
+        "parentId": "id-1",
+        "title": "Changed title of child",
+      },
+    ],
+    "id": "id-1",
+    "title": "Create a todo",
+  },
+]
+`;
+
+exports[`replay editing todos EDIT_TODO only edits the things provided in data and does not touch other fields 1`] = `
+Array [
+  Object {
+    "children": Array [
+      Object {
+        "id": "id-2",
+        "parentId": "id-1",
+        "title": "Changed title of child but did not change parentId",
+      },
+    ],
+    "id": "id-1",
+    "title": "Create a todo",
+  },
+]
+`;
+
+exports[`replay editing todos EDIT_TODO will change the todos when the edit is done 1`] = `
+Object {
+  "id": "id-1",
+  "title": "Changed the todo",
+}
+`;
+
+exports[`replay editing todos EDITING_TODO does not care in the store about intermediate edits 1`] = `
+Object {
+  "id": "id-1",
+  "title": "Create a todo",
+}
+`;

--- a/packages/storage-events/src/__snapshots__/replay.spec.js.snap
+++ b/packages/storage-events/src/__snapshots__/replay.spec.js.snap
@@ -72,7 +72,7 @@ Array [
 ]
 `;
 
-exports[`replay editing todos EDIT_TODO can edit child todos 1`] = `
+exports[`replay editing todos CHANGED_TODO can edit child todos 1`] = `
 Array [
   Object {
     "children": Array [
@@ -88,7 +88,7 @@ Array [
 ]
 `;
 
-exports[`replay editing todos EDIT_TODO only edits the things provided in data and does not touch other fields 1`] = `
+exports[`replay editing todos CHANGED_TODO only edits the things provided in data and does not touch other fields 1`] = `
 Array [
   Object {
     "children": Array [
@@ -104,7 +104,7 @@ Array [
 ]
 `;
 
-exports[`replay editing todos EDIT_TODO will change the todos when the edit is done 1`] = `
+exports[`replay editing todos CHANGED_TODO will change the todos when the edit is done 1`] = `
 Object {
   "id": "id-1",
   "title": "Changed the todo",

--- a/packages/storage-events/src/replay.js
+++ b/packages/storage-events/src/replay.js
@@ -4,8 +4,8 @@ function replay(events) {
       return addTodo(todos, event.data);
     } else if (event.event === "REMOVED_TODO") {
       return removeTodo(todos, event.data);
-    } else if (event.event === "EDIT_TODO") {
-      return editTodo(todos, event.data);
+    } else if (event.event === "CHANGED_TODO") {
+      return changedTodo(todos, event.data);
     }
     return todos;
   }, []);
@@ -35,20 +35,20 @@ function appendChild(todo, todoToAdd) {
   return todo;
 }
 
-function editTodo(todos, data) {
+function changedTodo(todos, data) {
   return todos.map(todo => {
     if (data.id === todo.id) {
-      return editSingleTodo(todo, data);
+      return editTodo(todo, data);
     } else {
       return {
         ...todo,
-        children: editTodo(todo.children, data)
+        children: changedTodo(todo.children, data)
       };
     }
   });
 }
 
-function editSingleTodo(todo, data) {
+function editTodo(todo, data) {
   return {
     ...todo,
     ...data

--- a/packages/storage-events/src/replay.js
+++ b/packages/storage-events/src/replay.js
@@ -4,6 +4,8 @@ function replay(events) {
       return addTodo(todos, event.data);
     } else if (event.event === "REMOVED_TODO") {
       return removeTodo(todos, event.data);
+    } else if (event.event === "EDIT_TODO") {
+      return editTodo(todos, event.data);
     }
     return todos;
   }, []);
@@ -12,9 +14,7 @@ function replay(events) {
 
 function addTodo(todos, todoToAdd) {
   if (todoToAdd.parentId) {
-    return todos.map(todo => {
-      return appendChild(todo, todoToAdd);
-    });
+    return todos.map(todo => appendChild(todo, todoToAdd));
   }
   return [...todos, todoToAdd];
 }
@@ -26,15 +26,33 @@ function appendChild(todo, todoToAdd) {
       children: [...(todo.children || []), todoToAdd]
     };
   } else if (todo.children && todo.children.length) {
-    let mappedChildren = todo.children.map(child => {
-      return appendChild(child, todoToAdd);
-    });
+    const mappedChildren = todo.children.map(child => appendChild(child, todoToAdd));
     return {
       ...todo,
       children: [...mappedChildren]
     };
   }
   return todo;
+}
+
+function editTodo(todos, data) {
+  return todos.map(todo => {
+    if (data.id === todo.id) {
+      return editSingleTodo(todo, data);
+    } else {
+      return {
+        ...todo,
+        children: editTodo(todo.children, data)
+      };
+    }
+  });
+}
+
+function editSingleTodo(todo, data) {
+  return {
+    ...todo,
+    ...data
+  };
 }
 
 function removeTodo(todos, data) {

--- a/packages/storage-events/src/replay.spec.js
+++ b/packages/storage-events/src/replay.spec.js
@@ -173,12 +173,12 @@ describe("replay", () => {
       });
       it("can change a todo description", () => {});
     });
-    describe("EDIT_TODO", () => {
+    describe("CHANGED_TODO", () => {
       it("will change the todos when the edit is done", () => {
         const events = [
           { event: "ADDED_TODO", data: { id: "id-1", title: "Create a todo" } },
           { event: "EDITING_TODO", data: { id: "id-1", title: "Changing the todo" } },
-          { event: "EDIT_TODO", data: { id: "id-1", title: "Changed the todo" } }
+          { event: "CHANGED_TODO", data: { id: "id-1", title: "Changed the todo" } }
         ];
         const state = replay(events);
         expect(state.todos.length).toEqual(1);
@@ -189,7 +189,7 @@ describe("replay", () => {
         const events = [
           { event: "ADDED_TODO", data: { id: "id-1", title: "Create a todo" } },
           { event: "ADDED_TODO", data: { id: "id-2", title: "Added a child", parentId: "id-1" } },
-          { event: "EDIT_TODO", data: { id: "id-2", title: "Changed title of child", parentId: "id-1" } }
+          { event: "CHANGED_TODO", data: { id: "id-2", title: "Changed title of child", parentId: "id-1" } }
         ];
         const state = replay(events);
         expect(state.todos.length).toEqual(1);
@@ -200,7 +200,7 @@ describe("replay", () => {
         const events = [
           { event: "ADDED_TODO", data: { id: "id-1", title: "Create a todo" } },
           { event: "ADDED_TODO", data: { id: "id-2", title: "Added a child", parentId: "id-1" } },
-          { event: "EDIT_TODO", data: { id: "id-2", title: "Changed title of child but did not change parentId" } }
+          { event: "CHANGED_TODO", data: { id: "id-2", title: "Changed title of child but did not change parentId" } }
         ];
         const state = replay(events);
         expect(state.todos.length).toEqual(1);

--- a/packages/storage-events/src/replay.spec.js
+++ b/packages/storage-events/src/replay.spec.js
@@ -171,9 +171,9 @@ describe("replay", () => {
         expect(state.todos.length).toEqual(1);
         expect(state.todos[0]).toMatchSnapshot();
       });
-      it("can change a todo description", () => {});
     });
-    describe("CHANGED_TODO", () => {
+
+		describe("CHANGED_TODO", () => {
       it("will change the todos when the edit is done", () => {
         const events = [
           { event: "ADDED_TODO", data: { id: "id-1", title: "Create a todo" } },

--- a/packages/storage-events/src/replay.spec.js
+++ b/packages/storage-events/src/replay.spec.js
@@ -158,4 +158,54 @@ describe("replay", () => {
       expect(state.todos[0].children.length).toEqual(1);
     });
   });
+
+  describe("editing todos", () => {
+    describe("EDITING_TODO", () => {
+      it("does not care in the store about intermediate edits", () => {
+        const events = [
+          { event: "ADDED_TODO", data: { id: "id-1", title: "Create a todo" } },
+          { event: "EDITING_TODO", data: { id: "id-1", title: "Changing the todo" } },
+          { event: "EDITING_TODO", data: { id: "id-1", title: "Still changing the todo" } }
+        ];
+        const state = replay(events);
+        expect(state.todos.length).toEqual(1);
+        expect(state.todos[0]).toMatchSnapshot();
+      });
+      it("can change a todo description", () => {});
+    });
+    describe("EDIT_TODO", () => {
+      it("will change the todos when the edit is done", () => {
+        const events = [
+          { event: "ADDED_TODO", data: { id: "id-1", title: "Create a todo" } },
+          { event: "EDITING_TODO", data: { id: "id-1", title: "Changing the todo" } },
+          { event: "EDIT_TODO", data: { id: "id-1", title: "Changed the todo" } }
+        ];
+        const state = replay(events);
+        expect(state.todos.length).toEqual(1);
+        expect(state.todos[0]).toMatchSnapshot();
+      });
+
+      it("can edit child todos", () => {
+        const events = [
+          { event: "ADDED_TODO", data: { id: "id-1", title: "Create a todo" } },
+          { event: "ADDED_TODO", data: { id: "id-2", title: "Added a child", parentId: "id-1" } },
+          { event: "EDIT_TODO", data: { id: "id-2", title: "Changed title of child", parentId: "id-1" } }
+        ];
+        const state = replay(events);
+        expect(state.todos.length).toEqual(1);
+        expect(state.todos).toMatchSnapshot();
+      });
+
+      it("only edits the things provided in data and does not touch other fields", () => {
+        const events = [
+          { event: "ADDED_TODO", data: { id: "id-1", title: "Create a todo" } },
+          { event: "ADDED_TODO", data: { id: "id-2", title: "Added a child", parentId: "id-1" } },
+          { event: "EDIT_TODO", data: { id: "id-2", title: "Changed title of child but did not change parentId" } }
+        ];
+        const state = replay(events);
+        expect(state.todos.length).toEqual(1);
+        expect(state.todos).toMatchSnapshot();
+      });
+    });
+  });
 });


### PR DESCRIPTION
The possibility to replay `CHANGED_TODO` events. This can change already added todos. I think this might be a good idea to have even though we technically could use `REMOVED_TODO` and `ADDED_TODO`, but if you only want to change a part like `parentId`, you'd need to attach all children as well.