### PR TITLE
Get Remove todos to work again

### DIFF
--- a/packages/server-web/src/client/component/TodoItem.vue
+++ b/packages/server-web/src/client/component/TodoItem.vue
@@ -1,10 +1,16 @@
 <template>
   <div :class="`todo-item todo-item-${todo.todoId}`" :ref="`todo-item-${todo.todoId}`">
-    <div :class="`todo ${todo.status === 'done' ? 'todo-done' : ''}`">
+    <div :class="`todo ${todo.status === 'done' ? 'todo-done' : ''} ${expanded && 'expanded'}`">
       <div :class="`dropzone-sub dropzone-${ isDragging ? 'active' : 'inactive' }`" v-if="!updating" ref="dropzoneSub"></div>
-			<todo-options @click.prevent="toggleAddTodoItem" :removeTodo="removeTodo" />
-      <span :class="`status status-${todo.status || 'open'}`" v-on:click="toggleStatus(todo)"></span>
-      <span class="id">#{{todo.todoId.substring(0, 4)}}</span>
+			<todo-options
+        :adderVisible="adderVisible"
+        :expanded="expanded"
+        :removeTodo="removeTodo"
+        :toggleTodoOptions="toggleTodoOptions"
+        :toggleAddTodoItem="toggleAddTodoItem"
+      />
+      <div :class="`status status-${todo.status || 'open'}`" v-on:click="toggleStatus(todo)"></div>
+      <div class="id">#{{todo.todoId.substring(0, 4)}}</div>
       <div>
         <span v-if="!updating" v-on:click="updating=true" :class="`title title-${todo.status || 'open'}`">{{todo.title}}</span>
         <todo-label v-if="!updating" v-for="label in todo.labels" :todoLabel="`${label}`" :key="label" />
@@ -70,6 +76,7 @@ export default {
   data() {
     return {
       adderVisible: false,
+      expanded: false,
       updating: false
     };
   },
@@ -117,9 +124,15 @@ export default {
       const newStatus = todo.status == "open" ? "done" : "open";
       commands.changeTodo(todo, { status: newStatus });
     },
+    toggleTodoOptions() {
+      if (this.expanded && this.adderVisible) {
+        this.toggleAddTodoItem();
+      }
+      this.expanded = !this.expanded;
+    },
     toggleAddTodoItem() {
-      this.$data.adderVisible = !this.$data.adderVisible;
-      if (this.$data.adderVisible) {
+      this.adderVisible = !this.adderVisible;
+      if (this.adderVisible) {
         // Set focus on the input field if adder is toggled to visible
         this.$nextTick(() => this.$refs.adder.$refs.input.focus());
       }
@@ -140,8 +153,14 @@ export default {
 .todo {
   position: relative;
   display: grid;
-  grid-template-columns: 25px 25px 40px max-content 1fr;
+  grid-template-columns: 25px 25px max-content max-content 1fr;
+  justify-items: center;
   align-items: center;
+}
+.todo.expanded {
+  margin-left: -25px;
+  grid-template-columns: 50px 25px max-content max-content 1fr;
+  justify-items: left;
 }
 .todo-done {
   font-size: 0.9em;
@@ -158,7 +177,6 @@ export default {
 }
 
 .id {
-  margin-right: 5px;
   color: var(--notice-small-color);
 }
 

--- a/packages/server-web/src/client/component/TodoItem.vue
+++ b/packages/server-web/src/client/component/TodoItem.vue
@@ -2,7 +2,7 @@
   <div :class="`todo-item todo-item-${todo.todoId}`" :ref="`todo-item-${todo.todoId}`">
     <div :class="`todo ${todo.status === 'done' ? 'todo-done' : ''}`">
       <div :class="`dropzone-sub dropzone-${ isDragging ? 'active' : 'inactive' }`" v-if="!updating" ref="dropzoneSub"></div>
-			<todo-options @click.prevent="toggleAddTodoItem()" />
+			<todo-options @click.prevent="toggleAddTodoItem" :removeTodo="removeTodo" />
       <span :class="`status status-${todo.status || 'open'}`" v-on:click="toggleStatus(todo)"></span>
       <span class="id">#{{todo.todoId.substring(0, 4)}}</span>
       <div>
@@ -124,8 +124,9 @@ export default {
         this.$nextTick(() => this.$refs.adder.$refs.input.focus());
       }
     },
-    removeTodo(todo) {
-      return () => this.$props.commands.removeTodo(todo);
+    removeTodo() {
+      const { commands, todo } = this.$props;
+      return commands.removeTodo(todo);
     }
   }
 };

--- a/packages/server-web/src/client/component/TodoOptions.vue
+++ b/packages/server-web/src/client/component/TodoOptions.vue
@@ -1,15 +1,14 @@
 <template>
-	<div class="options">
-    <div class="move"><i class="fas fa-ellipsis-v" /></div>
-		<div class="toggle-wrap boxed">
-			<div class="remove" @click.prevent="removeTodo()"><i class="fas fa-trash" /></div>
-		</div>
+	<div :class="`options ${this.$props.expanded ? 'expanded' : ''}`">
+    <div class="move" @click.prevent="toggleTodoOptions()"><i class="fas fa-ellipsis-v" /></div>
+		<div class="add" @click.prevent="toggleAddTodoItem()"><i :class="`fas fa-${this.$props.adderVisible ? 'minus' : 'plus'}`" /></div>
+		<div class="remove" @click.prevent="removeTodo()"><i class="fas fa-trash" /></div>
 	</div>
 </template>
 
 <script>
 export default {
-  props: ["adderVisible", "drag", "removeTodo", "toggleAddTodoItem"]
+  props: ["adderVisible", "drag", "expanded", "removeTodo", "toggleAddTodoItem", "toggleTodoOptions"]
 };
 </script>
 
@@ -20,14 +19,27 @@ export default {
   padding: 0;
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
+  justify-content: space-around;
   align-items: center;
 }
-.options .boxed > div {
-  margin: 0 5px;
+.options.expanded {
+  width: 50px;
+}
+.options .add,
+.options .remove {
+  display: none;
+}
+.options.expanded .add,
+.options.expanded .remove {
+  display: flex;
+}
+.options .inactive {
+  display: none;
 }
 .options .move {
-  cursor: move;
+}
+.options .add {
+  cursor: hand;
 }
 .options .remove {
   cursor: crosshair;


### PR DESCRIPTION
**Please check or ~strike-through~ all of the following**
This pull-request
- [x] resolves #77 
- [x] has a meaningful title
- [x] complies to the [code of conduct](../blob/master/CODE_OF_CONDUCT.md)
- ~installs new dependencies through `npm run bootstrap`~
- ~contains a breaking change~

**Changes**
- Adds a toggle for the option menu by clicking on the ellipsis
- Adds the possibility to remove todos
- Fixes toggle add sub-todo item (unsure if we should kick that in the current form)
