### PR TITLE
make store replay an (async) action

### DIFF
--- a/packages/server-web/src/client/client.js
+++ b/packages/server-web/src/client/client.js
@@ -2,6 +2,6 @@ import createSocketConnection from "./socket-connection.js";
 import createApp from "./create-app.js";
 import { store } from "./store.js";
 
-const processEvent = event => store.commit("processEvent", event);
+const processEvent = event => store.dispatch("processEvent", event);
 const commands = createSocketConnection(processEvent);
 createApp(commands);

--- a/packages/server-web/src/client/store.js
+++ b/packages/server-web/src/client/store.js
@@ -8,9 +8,9 @@ export const store = new Vuex.Store({
   state: {
     isDragging: false,
     allEvents: [],
-    currentEventPositon: -1,
+    currentEventPosition: -1,
     todos: [],
-    commands: [],
+    commands: {},
     isAuthenticated: false,
     isLoading: false
   },
@@ -46,15 +46,34 @@ export const store = new Vuex.Store({
     commands(state, commands) {
       state.commands = commands;
     },
-    processEvent(state, event) {
-      if (event.position > state.currentEventPositon) {
-        state.allEvents.push(event);
-        state.currentEventPositon = event.position;
-        state.todos = replay(state.allEvents).todos;
-      }
+    currentEventPosition(state, position) {
+      state.currentEventPosition = position;
+    },
+    todos(state, newTodos) {
+      state.todos = newTodos;
     },
     changePassword(state, val) {
       state.commands.changePassword(val);
+    },
+    addEventToAllEvents(state, event) {
+      state.allEvents = state.allEvents = [...state.allEvents, event];
+    }
+  },
+  actions: {
+    processEvent(context, event) {
+      new Promise((resolve, reject) => {
+        try {
+          if (event.position > context.state.currentEventPosition) {
+            context.commit("addEventToAllEvents", event);
+            context.commit("currentEventPosition", event.position);
+            const todos = replay(context.state.allEvents).todos;
+            context.commit("todos", todos);
+          }
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
     }
   }
 });

--- a/packages/server-web/src/client/store.js
+++ b/packages/server-web/src/client/store.js
@@ -56,7 +56,7 @@ export const store = new Vuex.Store({
       state.commands.changePassword(val);
     },
     addEventToAllEvents(state, event) {
-      state.allEvents = state.allEvents = [...state.allEvents, event];
+      state.allEvents = [...state.allEvents, event];
     }
   },
   actions: {


### PR DESCRIPTION
**Please check or ~strike-through~ all of the following**
This pull-request
- ~resolves #<issue-id>~ maybe resolves the bug with the double tree
- [x] has a meaningful title
- ~contains a breaking change, which is documented in the [changelog](../blob/master/CHANGELOG.md)~
- ~contains a new feature, which is documented in the [changelog](../blob/master/CHANGELOG.md)~
- [x] complies to the [code of conduct](../blob/master/CODE_OF_CONDUCT.md)
- ~installs new dependencies through `npm run bootstrap`~

**Changes**
- Make vuex replay all events in an action instead of a mutation
