### PR TITLE
Update user-add.js to fix broken demo labels

### DIFF
--- a/packages/konsol/src/user-add.js
+++ b/packages/konsol/src/user-add.js
@@ -70,22 +70,22 @@ function defaultLanguage() {
 function eventsDe(user, uid){
   return [
     { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "1", title: "Ein erstes Todo erstellen", position: 0 } },
-    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "1-1", labels: ["power"], title: "Ein erstes Sub Todo erstellen", position: 0, parentId: uid + "1" } },
+    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "1-1", labels: ["#power"], title: "Ein erstes Sub Todo erstellen", position: 0, parentId: uid + "1" } },
     { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "1-1-1", title: "Auf die drei Punkte klicken", position: 0, parentId: uid + "1-1" } },
     { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "1-1-2", title: "Auf 'plus' klicken", position: 1, parentId: uid + "1-1" } },
     { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "1-1-3", title: "Todo Text in das Feld eintragen", position: 2, parentId: uid + "1-1" } },
     { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "1-2", title: "Todo an eine andere Position verschieben", position: 1, parentId: uid + "1" } },
     { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "1-2-1", title: "Drag and drop verwenden", position: 0, parentId: uid + "2-1" } },
-    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "2", labels: ["security"], title: "Passwort ändern", position: 1 } },
-    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "3", labels: ["help-us", "please"], title: "Dem neugierigen Todastic Team tiefgründiges Feedback geben", position: 2 } },
+    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "2", labels: ["#security"], title: "Passwort ändern", position: 1 } },
+    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "3", labels: ["#help-us", "#please"], title: "Dem neugierigen Todastic Team tiefgründiges Feedback geben", position: 2 } },
     { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "3-1", title: "Über das Fragezeichen (?) rechts oben die Feedback E-Mailadresse finden", position: 0, parentId: uid + "3" } },
     { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "3-2", labels:["#fun"], title: "2 Minuten mit Todastic herumspielen", position: 1, parentId: uid + "3" } },
-    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4", labels:["time"], title: "Eine Zeit tracken", position: 3 } },
-    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4-1", labels:["time"], title: "Zeit eintragen", position: 0, parentId: uid + "4" } },
-    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4-2", labels:["time"], title: "Zeit ändern", position: 1, parentId: uid + "4" } },
-    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4-3", labels:["time"], title: "Die getrackte Zeit über ein Skript ausgeben lassen", position: 2, parentId: uid + "4" } },
-    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4-3-1", labels:["time", "automation"], title: "Skript aus dem Wiki kopieren (https://github.com/compose-us/todastic/wiki/User-scripts)", position: 0, parentId: uid + "4-3" } },
-    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4-3-2", labels:["time", "automation"], title: "Skript laufen lassen", position: 1, parentId: uid + "4-3" } },
+    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4", labels:["#time"], title: "Eine Zeit tracken", position: 3 } },
+    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4-1", labels:["#time"], title: "Zeit eintragen", position: 0, parentId: uid + "4" } },
+    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4-2", labels:["#time"], title: "Zeit ändern", position: 1, parentId: uid + "4" } },
+    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4-3", labels:["#time"], title: "Die getrackte Zeit über ein Skript ausgeben lassen", position: 2, parentId: uid + "4" } },
+    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4-3-1", labels:["#time", "#automation"], title: "Skript aus dem Wiki kopieren (https://github.com/compose-us/todastic/wiki/User-scripts)", position: 0, parentId: uid + "4-3" } },
+    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4-3-2", labels:["#time", "#automation"], title: "Skript laufen lassen", position: 1, parentId: uid + "4-3" } },
     { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4-3-3", labels: ["#yay"], title: "Ergebnis begutachten", position: 2, parentId: uid + "4-3" } }
   ];
 }
@@ -93,22 +93,22 @@ function eventsDe(user, uid){
 function eventsEn(user, uid){
   return [
     { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "1", title: "Create a first Todo", position: 0 } },
-    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "1-1", labels: ["power"], title: "Create a first Sub Todo", position: 0, parentId: uid + "1" } },
+    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "1-1", labels: ["#power"], title: "Create a first Sub Todo", position: 0, parentId: uid + "1" } },
     { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "1-1-1", title: "Click on the three dots", position: 0, parentId: uid + "1-1" } },
     { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "1-1-2", title: "click on 'plus'", position: 1, parentId: uid + "1-1" } },
     { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "1-1-3", title: "Write a sub Todo in the text field", position: 2, parentId: uid + "1-1" } },
     { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "1-2", title: "Move a todo to a different position", position: 1, parentId: uid + "1" } },
     { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "1-2-1", title: "Use drag and drop", position: 0, parentId: uid + "2-1" } },
-    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "2", labels: ["security"], title: "Change password", position: 1 } },
+    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "2", labels: ["#security"], title: "Change password", position: 1 } },
     { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "3", labels: ["help-us", "please"], title: "Give the curious todastic team feedback", position: 2 } },
     { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "3-1", title: "Find email address via (?) at the upper right", position: 0, parentId: uid + "3" } },
     { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "3-2", labels:["#fun"], title: "Play with Todastic for 2 minutes", position: 1, parentId: uid + "3" } },
-    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4", labels:["time"], title: "Explore time tracking", position: 3 } },
-    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4-1", labels:["time"], title: "Add a time entry", position: 0, parentId: uid + "4" } },
-    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4-2", labels:["time"], title: "Change time entry", position: 1, parentId: uid + "4" } },
-    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4-3", labels:["time"], title: "See the tracked time via a script", position: 2, parentId: uid + "4" } },
-    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4-3-1", labels:["time", "automation"], title: "Copy script from the wiki (https://github.com/compose-us/todastic/wiki/User-scripts)", position: 0, parentId: uid + "4-3" } },
-    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4-3-2", labels:["time", "automation"], title: "Run the script", position: 1, parentId: uid + "4-3" } },
+    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4", labels:["#time"], title: "Explore time tracking", position: 3 } },
+    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4-1", labels:["#time"], title: "Add a time entry", position: 0, parentId: uid + "4" } },
+    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4-2", labels:["#time"], title: "Change time entry", position: 1, parentId: uid + "4" } },
+    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4-3", labels:["#time"], title: "See the tracked time via a script", position: 2, parentId: uid + "4" } },
+    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4-3-1", labels:["#time", "#automation"], title: "Copy script from the wiki (https://github.com/compose-us/todastic/wiki/User-scripts)", position: 0, parentId: uid + "4-3" } },
+    { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4-3-2", labels:["#time", "#automation"], title: "Run the script", position: 1, parentId: uid + "4-3" } },
     { eventType: "ADDED_TODO", userId: user._id, data: { todoId: uid + "4-3-3", labels: ["#yay"], title: "Look at results", position: 2, parentId: uid + "4-3" } }
   ];
 }


### PR DESCRIPTION
Fix labels

**Please check or ~strike-through~ all of the following**
This pull-request
- ~resolves #<issue-id>~ (is adhoc fix)
- [x] has a meaningful title
- ~contains a breaking change, which is documented in the [changelog](../blob/master/CHANGELOG.md)~
- ~contains a new feature, which is documented in the [changelog](../blob/master/CHANGELOG.md)~
- [x] complies to the [code of conduct](../blob/master/CODE_OF_CONDUCT.md)
- ~installs new dependencies through `npm run bootstrap`~

**Changes**
- Consistently adds `#` to labels for our demo