### PR TITLE
Fix/46 <esc> closes windows

### DIFF
--- a/packages/server-web/config/webpack/config.js
+++ b/packages/server-web/config/webpack/config.js
@@ -102,6 +102,6 @@ module.exports = ({ extractStyles = true } = {}) => {
         }
       })
     ],
-    stats: "errors-only"
+    stats: "minimal"
   };
 };

--- a/packages/server-web/src/client/component/Help.vue
+++ b/packages/server-web/src/client/component/Help.vue
@@ -1,7 +1,7 @@
 <template>
 	<transition name="modal">
     <div :class="$style.modalMask">
-      <div :class="$style.modalWrapper">
+      <div :class="$style.modalWrapper" v-on:click="close">
         <div :class="$style.modalContainer">
 
           <div :class="$style.modalHeader">
@@ -78,7 +78,7 @@ export default {
     close() {
       this.$emit('close');
     },
-    escapeKeyListener: function(event) {
+    escapeKeyListener(event) {
       if (event.keyCode === 27) {
         this.close();
       }
@@ -118,7 +118,7 @@ export default {
 }
 .modalMask {
   position: fixed;
-  z-index: 9998;
+  z-index: 5;
   top: 0;
   left: 0;
   width: 100%;

--- a/packages/server-web/src/client/component/Help.vue
+++ b/packages/server-web/src/client/component/Help.vue
@@ -60,7 +60,7 @@
           <div :class="$style.modalFooter">
             <slot name="footer">
               <a href="mailto:feedback@todastic.app">Feedback / Contact</a>
-              <button :class="$style.modalDefaultButton" @click="$emit('close')">
+              <button :class="$style.modalDefaultButton" @click="close">
                 Close
               </button>
             </slot>
@@ -73,7 +73,23 @@
 
 <script>
 export default {
-  name: "Help"
+  name: "Help",
+  methods: {
+    close() {
+      this.$emit('close');
+    },
+    escapeKeyListener: function(event) {
+      if (event.keyCode === 27) {
+        this.close();
+      }
+    }
+  },
+  created() {
+    document.addEventListener('keyup', this.escapeKeyListener);
+  },
+  destroyed() {
+    document.removeEventListener('keyup', this.escapeKeyListener);
+  },
 };
 </script>
 

--- a/packages/server-web/src/client/component/TodoItem.vue
+++ b/packages/server-web/src/client/component/TodoItem.vue
@@ -15,9 +15,9 @@
         <span v-on:click="updating=true" :class="{[$style.title]: true, [$style.titleOpen]: todo.status === 'open', [$style.titleDone]: todo.status === 'done' }">{{todo.title}}</span>
         <todo-label v-for="label in todo.labels" :todoLabel="`${label}`" :key="label" />
       </div>
-      <todo-text v-if="updating" ref="updater" :visible="updating" v-on:cancel="cancel" v-on:change="updateTitle" v-bind.sync="{ initialTodoTitle: completeText }" :key="`updateTodo-${todo.todoId}`" />
+      <todo-text v-if="updating" v-on:cancel="cancel" v-on:change="updateTitle" v-bind.sync="{ initialTodoTitle: completeText }" :key="`updateTodo-${todo.todoId}`" />
     </div>
-    <todo-text ref="adder" v-on:change="addTodo" :visible="adderVisible" v-on:cancel="cancel" :key="`addTodo-${todo.todoId}`" :parentId="todo.todoId" />
+    <todo-text v-if="adderVisible" ref="adder" v-on:change="addTodo" v-on:cancel="cancel" :key="`addTodo-${todo.todoId}`" :parentId="todo.todoId" />
   </div>
 </template>
 

--- a/packages/server-web/src/client/component/TodoItem.vue
+++ b/packages/server-web/src/client/component/TodoItem.vue
@@ -15,9 +15,9 @@
         <span v-on:click="updating=true" :class="{[$style.title]: true, [$style.titleOpen]: todo.status === 'open', [$style.titleDone]: todo.status === 'done' }">{{todo.title}}</span>
         <todo-label v-for="label in todo.labels" :todoLabel="`${label}`" :key="label" />
       </div>
-      <todo-text v-if="updating" ref="updater" :visible="updating" v-on:change="updateTitle" v-bind.sync="{ initialTodoTitle: completeText }" :key="`updateTodo-${todo.todoId}`" />
+      <todo-text v-if="updating" ref="updater" :visible="updating" v-on:cancel="cancel" v-on:change="updateTitle" v-bind.sync="{ initialTodoTitle: completeText }" :key="`updateTodo-${todo.todoId}`" />
     </div>
-    <todo-text ref="adder" v-on:change="addTodo" :visible="adderVisible" :key="`addTodo-${todo.todoId}`" :parentId="todo.todoId" />
+    <todo-text ref="adder" v-on:change="addTodo" :visible="adderVisible" v-on:cancel="cancel" :key="`addTodo-${todo.todoId}`" :parentId="todo.todoId" />
   </div>
 </template>
 
@@ -81,6 +81,9 @@ export default {
     };
   },
   methods: {
+    cancel() {
+      this.updating = false;
+    },
     handleDropzoneEnter(event) {},
     handleDropzoneOver(event) {
       event.preventDefault();

--- a/packages/server-web/src/client/component/TodoText.vue
+++ b/packages/server-web/src/client/component/TodoText.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="{[$style.todoText]: true, [$style.hide]: !visible}">
-    <input ref="input" type="text" :class="$style.createTodo" @keyup.enter.prevent="change" :value="todoTitle" :placeholder="placeholder" />
+    <input ref="input" type="text" :class="$style.createTodo" @blur="change" @keyup.enter.prevent="change" :value="todoTitle" :placeholder="placeholder" />
   </div>
 </template>
 

--- a/packages/server-web/src/client/component/TodoText.vue
+++ b/packages/server-web/src/client/component/TodoText.vue
@@ -14,7 +14,8 @@ export default {
   data() {
     return {
       // we don't want to change the parent element's title directly
-      placeholder: getPlaceholder()
+      placeholder: getPlaceholder(),
+      active: this.$props.visible
     };
   },
   computed: {
@@ -26,7 +27,10 @@ export default {
     cancel() {
       if (this.$props.visible) {
         this.$data.todoTitle = this.$props.initialTodoTitle;
-        this.$emit('cancel');
+        // have to set state to inactive, otherwise we get another blur event that would
+        // trigger a save
+        this.$data.active = false;
+        this.$emit("cancel");
       }
     },
     escapeKeyListener(event) {
@@ -34,8 +38,11 @@ export default {
         this.cancel();
       }
     },
+    isChangeEvent(event) {
+      return event.target.value !== "" && (event.type === "keyup" || event.type === "blur") && this.$data.active;
+    },
     change(event) {
-      if(event.target.value !== "" && event.type === "keyup") {
+      if (this.isChangeEvent(event)) {
         this.$emit("change", event.target.value);
         // means, we are in "add new" mode
         if (!this.$props.initialTodoTitle) {
@@ -46,11 +53,11 @@ export default {
     }
   },
   created() {
-    document.addEventListener('keyup', this.escapeKeyListener);
+    document.addEventListener("keyup", this.escapeKeyListener);
   },
   destroyed() {
-    document.removeEventListener('keyup', this.escapeKeyListener);
-  },
+    document.removeEventListener("keyup", this.escapeKeyListener);
+  }
 };
 
 function getPlaceholder() {

--- a/packages/server-web/src/client/component/TodoText.vue
+++ b/packages/server-web/src/client/component/TodoText.vue
@@ -23,8 +23,19 @@ export default {
     }
   },
   methods: {
+    cancel() {
+      if (this.$props.visible) {
+        this.$data.todoTitle = this.$props.initialTodoTitle;
+        this.$emit('cancel');
+      }
+    },
+    escapeKeyListener(event) {
+      if (event.keyCode === 27) {
+        this.cancel();
+      }
+    },
     change(event) {
-      if(event.target.value !== "") {
+      if(event.target.value !== "" && event.type === "keyup") {
         this.$emit("change", event.target.value);
         // means, we are in "add new" mode
         if (!this.$props.initialTodoTitle) {
@@ -33,7 +44,13 @@ export default {
         }
       }
     }
-  }
+  },
+  created() {
+    document.addEventListener('keyup', this.escapeKeyListener);
+  },
+  destroyed() {
+    document.removeEventListener('keyup', this.escapeKeyListener);
+  },
 };
 
 function getPlaceholder() {


### PR DESCRIPTION
**Please check or ~strike-through~ all of the following**
This pull-request
- [x] resolves #46
- [x] has a meaningful title
- ~contains a breaking change, which is documented in the [changelog](../blob/master/CHANGELOG.md)~
- ~contains a new feature, which is documented in the [changelog](../blob/master/CHANGELOG.md)~
- [x] complies to the [code of conduct](../blob/master/CODE_OF_CONDUCT.md)
- ~installs new dependencies through `npm run bootstrap`~

**Changes**
- Adds the option to <ESC> while inputing text. Nothing will be changed
- Adds the option to click somewhere else while inputing text. Changes will be saved
- Adds the option to close Help screen via <ESC> or any click