### PR TITLE
Remove second logo from Login.vue

### DIFF
--- a/packages/server-web/src/client/component/Login.vue
+++ b/packages/server-web/src/client/component/Login.vue
@@ -1,6 +1,5 @@
 <template>
   <div :class="$style.todasticapp">
-    <img src="image/todastic-logo.svg" />
     <span></span> <!-- quickfix for grid layout -->
     <div>
       <input :class="$style.loginInputField" type="text" name="username" v-model="input.username" placeholder="Username" />


### PR DESCRIPTION
**Please check or ~strike-through~ all of the following**
This pull-request
- ~resolves #<issue-id>~
- [x] has a meaningful title
- ~contains a breaking change~
- ~contains a new feature~
- [x] complies to the [code of conduct](../blob/master/CODE_OF_CONDUCT.md)
- ~installs new dependencies through `npm run bootstrap`~

**Changes**
- just saw that we currently have two logos at login
