### PR TITLE
fix <ESC> no longer aborting

### DIFF
--- a/packages/server-web/src/client/component/TodoItem.vue
+++ b/packages/server-web/src/client/component/TodoItem.vue
@@ -109,8 +109,7 @@ export default {
     return {
       adderVisible: false,
       expanded: false,
-      icons,
-      updating: false
+      icons
     };
   },
   methods: {

--- a/packages/server-web/src/client/component/TodoItem.vue
+++ b/packages/server-web/src/client/component/TodoItem.vue
@@ -115,7 +115,7 @@ export default {
   },
   methods: {
     cancel() {
-      this.updating = false;
+      this.$store.commit("isEditing", { [this.$props.todo.todoId]: false });
     },
     handleDropzoneEnter(event) {},
     handleDropzoneOver(event) {


### PR DESCRIPTION
**Please check or ~strike-through~ all of the following**
This pull-request
- [x] resolves #125 
- [x] has a meaningful title
- ~contains a breaking change~
- ~contains a new feature~
- [x] complies to the [code of conduct](../blob/master/CODE_OF_CONDUCT.md)
- ~installs new dependencies through `npm run bootstrap`~

**Changes**
- I thought initially, onblur was broken as well. But that worked just fine. Only cancel didn't work. Turns out, it's managed by the global state now instead of just the component.
