### PR TITLE
Fix GET /login route to show something even when no user and pass are…

### DIFF
--- a/packages/server-web/src/server/service/authentication.js
+++ b/packages/server-web/src/server/service/authentication.js
@@ -22,12 +22,9 @@ function register({
   app.get(
     loginRoute,
     (req, res, next) => {
-      logger.info("test?!");
       if (req.query.username && req.query.password) {
-        logger.info("user and password provided");
         next();
       } else {
-        logger.info("nothing provided!");
         res.redirect(indexRoute);
       }
     },
@@ -53,7 +50,6 @@ function register({
 
 function loggedIn(logger) {
   return (req, res, next) => {
-    logger.debug("Checking whether user is authenticated");
     if (!req.isAuthenticated || !req.isAuthenticated()) {
       logger.info("User not authenticated!");
       res.sendStatus(401);
@@ -70,7 +66,6 @@ function init({ passport, User, logger }) {
         username: username
       },
       function(err, user) {
-        logger.info("something");
         logger.debug("Authentication: Found user.");
         if (err) {
           return done(err);

--- a/packages/server-web/src/server/service/authentication.js
+++ b/packages/server-web/src/server/service/authentication.js
@@ -19,9 +19,23 @@ function register({
   app.use(passport.initialize());
   app.use(passport.session());
 
-  app.get(loginRoute, passport.authenticate("local"), (req, res) => {
-    res.redirect(indexRoute);
-  });
+  app.get(
+    loginRoute,
+    (req, res, next) => {
+      logger.info("test?!");
+      if (req.query.username && req.query.password) {
+        logger.info("user and password provided");
+        next();
+      } else {
+        logger.info("nothing provided!");
+        res.redirect(indexRoute);
+      }
+    },
+    passport.authenticate("local"),
+    (req, res) => {
+      res.redirect(indexRoute);
+    }
+  );
 
   app.post(loginRoute, passport.authenticate("local"), (req, res) => {
     res.redirect(indexRoute);
@@ -56,6 +70,7 @@ function init({ passport, User, logger }) {
         username: username
       },
       function(err, user) {
+        logger.info("something");
         logger.debug("Authentication: Found user.");
         if (err) {
           return done(err);


### PR DESCRIPTION
… provided

Signed-off-by: Joern Bernhardt <joern.bernhardt@googlemail.com>

**Please check or ~strike-through~ all of the following**
This pull-request
- [x] resolves #127 
- [x] has a meaningful title
- ~contains a breaking change~
- ~contains a new feature~
- [x] complies to the [code of conduct](../blob/master/CODE_OF_CONDUCT.md)
- ~installs new dependencies through `npm run bootstrap`~

**Changes**
- Add middleware function to check if query parameters were provided. If none: Redirect to index and let frontend logic handle everything
