### PR TITLE
Drag + ALT key copies todos

### DIFF
--- a/packages/server-web/src/client/component/TodoItem.vue
+++ b/packages/server-web/src/client/component/TodoItem.vue
@@ -121,7 +121,7 @@ export default {
     handleDropzoneEnter(event) {},
     handleDropzoneOver(event) {
       event.preventDefault();
-      event.dataTransfer.dropEffect = "move";
+      event.dataTransfer.dropEffect = "copyMove";
       event.target.classList.remove(this.$style.activeBottom);
       event.target.classList.add(this.$style.activeBottom);
       return false;
@@ -134,7 +134,11 @@ export default {
       const { commands } = this.$store.getters;
       event.target.classList.remove(this.$style.activeBottom);
       const myTodo = JSON.parse(event.dataTransfer.getData("json/todo"));
-      commands.moveTodo(myTodo, { parentId: todo.todoId, position: todo.position + 1 });
+      if (event.altKey) {
+        commands.copyTodo(myTodo, todo.todoId);
+      } else {
+        commands.moveTodo(myTodo, { parentId: todo.todoId, position: todo.position + 1 });
+      }
     },
     updateTitle(newTitle) {
       const { todo } = this.$props;

--- a/packages/server-web/src/client/component/TodoList.vue
+++ b/packages/server-web/src/client/component/TodoList.vue
@@ -77,7 +77,7 @@ export default {
       const todoId = event.target.getAttribute("todoid");
       if (!this.$store.getters.isEditing[todoId]) {
         event.target.classList.add(this.$style.dragging);
-        event.dataTransfer.effectAllowed = "move";
+        event.dataTransfer.effectAllowed = "copyMove";
         const todo = todos.find(t => t.todoId === todoId);
         event.dataTransfer.setData("json/todo", JSON.stringify(todo));
         this.$store.commit("isDragging", true);
@@ -96,7 +96,7 @@ export default {
     handleDropzoneOver(event) {
       event.stopPropagation();
       event.preventDefault();
-      event.dataTransfer.dropEffect = "move";
+      event.dataTransfer.dropEffect = "copyMove";
       event.target.classList.remove(this.$style.activeTop);
       event.target.classList.remove(this.$style.activeBottom);
 
@@ -122,7 +122,11 @@ export default {
       const myTodo = JSON.parse(event.dataTransfer.getData("json/todo"));
       const position = parseInt(event.target.getAttribute("position"));
       const myPosition = position + (this.isTopHalf(event) ? 0 : 1);
-      commands.moveTodo(myTodo, { parentId, position: myPosition });
+      if (event.altKey) {
+        commands.copyTodo(myTodo, parentId);
+      } else {
+        commands.moveTodo(myTodo, { parentId, position: myPosition });
+      }
     },
     isTopHalf(event) {
       const rect = event.target.getBoundingClientRect();

--- a/packages/server-web/src/client/socket-connection.js
+++ b/packages/server-web/src/client/socket-connection.js
@@ -1,3 +1,4 @@
+import { stateToCommands } from "@todastic/storage-events";
 import io from "./socket.io-bundle.js";
 import { extractDetails } from "../lib/details-extractor.js";
 
@@ -8,6 +9,10 @@ export default function createSocketConnection(eventProcessor) {
     addTodo(todo) {
       const { text, labels, trackedTimes } = extractDetails(todo.title);
       socket.emit("command", { command: "ADD_TODO", data: { ...todo, labels, trackedTimes, title: text } });
+    },
+    copyTodo(todo, parentId) {
+      const copyCommands = stateToCommands([todo], parentId);
+      copyCommands.map(command => socket.emit("command", command));
     },
     removeTodo(todo) {
       socket.emit("command", { command: "REMOVE_TODO", data: { todoId: todo.todoId } });

--- a/packages/storage-events/src/__mocks__/state-to-commands-add-todo-complex.json
+++ b/packages/storage-events/src/__mocks__/state-to-commands-add-todo-complex.json
@@ -1,0 +1,54 @@
+[
+  {
+    "children": [
+      { "children": [], "todoId": "1-1", "labels": [], "position": 0, "status": "open", "title": "One-One" },
+      {
+        "children": [
+          { "children": [], "todoId": "1-2-1", "labels": [], "position": 0, "status": "open", "title": "One-Two-One" },
+          { "children": [], "todoId": "1-2-2", "labels": [], "position": 1, "status": "open", "title": "One-Two-Two" }
+        ],
+        "todoId": "1-2",
+        "labels": [],
+        "position": 1,
+        "status": "open",
+        "title": "One-Two"
+      },
+      { "children": [], "todoId": "1-3", "labels": [], "position": 2, "status": "open", "title": "One-Three" }
+    ],
+    "todoId": "1",
+    "labels": [],
+    "position": 0,
+    "status": "open",
+    "title": "One"
+  },
+  {
+    "children": [
+      { "children": [], "todoId": "2-1", "labels": [], "position": 0, "status": "open", "title": "Two-One" },
+      { "children": [], "todoId": "2-2", "labels": [], "position": 1, "status": "open", "title": "Two-Two" }
+    ],
+    "todoId": "2",
+    "labels": [],
+    "position": 1,
+    "status": "open",
+    "title": "Two"
+  },
+  {
+    "children": [],
+    "todoId": "3",
+    "labels": [],
+    "position": 2,
+    "status": "open",
+    "title": "Three"
+  },
+  {
+    "children": [
+      { "children": [], "todoId": "4-1", "labels": [], "position": 0, "status": "open", "title": "Four-One" },
+      { "children": [], "todoId": "4-2", "labels": [], "position": 1, "status": "open", "title": "Four-Two" }
+    ],
+    "todoId": "4",
+    "labels": [],
+    "position": 3,
+    "status": "open",
+    "title": "Four"
+  }
+]

--- a/packages/storage-events/src/__snapshots__/state-to-commands.spec.js.snap
+++ b/packages/storage-events/src/__snapshots__/state-to-commands.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`stateToCommands returns working complex ADD_TODO commands 1`] = `
 Array [
   Object {
+    "command": "ADD_TODO",
     "data": Object {
       "children": Array [
         Object {
@@ -48,9 +49,9 @@ Array [
       "status": "open",
       "title": "One",
     },
-    "type": "ADD_TODO",
   },
   Object {
+    "command": "ADD_TODO",
     "data": Object {
       "children": Array [
         Object {
@@ -74,9 +75,9 @@ Array [
       "status": "open",
       "title": "Two",
     },
-    "type": "ADD_TODO",
   },
   Object {
+    "command": "ADD_TODO",
     "data": Object {
       "children": Array [],
       "labels": Array [],
@@ -85,9 +86,9 @@ Array [
       "status": "open",
       "title": "Three",
     },
-    "type": "ADD_TODO",
   },
   Object {
+    "command": "ADD_TODO",
     "data": Object {
       "children": Array [
         Object {
@@ -111,7 +112,6 @@ Array [
       "status": "open",
       "title": "Four",
     },
-    "type": "ADD_TODO",
   },
 ]
 `;
@@ -119,6 +119,7 @@ Array [
 exports[`stateToCommands returns working complex ADD_TODO commands with parentId 1`] = `
 Array [
   Object {
+    "command": "ADD_TODO",
     "data": Object {
       "children": Array [
         Object {
@@ -164,9 +165,9 @@ Array [
       "status": "open",
       "title": "One",
     },
-    "type": "ADD_TODO",
   },
   Object {
+    "command": "ADD_TODO",
     "data": Object {
       "children": Array [
         Object {
@@ -190,9 +191,9 @@ Array [
       "status": "open",
       "title": "Two",
     },
-    "type": "ADD_TODO",
   },
   Object {
+    "command": "ADD_TODO",
     "data": Object {
       "children": Array [],
       "labels": Array [],
@@ -201,9 +202,9 @@ Array [
       "status": "open",
       "title": "Three",
     },
-    "type": "ADD_TODO",
   },
   Object {
+    "command": "ADD_TODO",
     "data": Object {
       "children": Array [
         Object {
@@ -227,7 +228,6 @@ Array [
       "status": "open",
       "title": "Four",
     },
-    "type": "ADD_TODO",
   },
 ]
 `;

--- a/packages/storage-events/src/__snapshots__/state-to-commands.spec.js.snap
+++ b/packages/storage-events/src/__snapshots__/state-to-commands.spec.js.snap
@@ -115,3 +115,119 @@ Array [
   },
 ]
 `;
+
+exports[`stateToCommands returns working complex ADD_TODO commands with parentId 1`] = `
+Array [
+  Object {
+    "data": Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "labels": Array [],
+          "position": 0,
+          "status": "open",
+          "title": "One-One",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "labels": Array [],
+              "position": 0,
+              "status": "open",
+              "title": "One-Two-One",
+            },
+            Object {
+              "children": Array [],
+              "labels": Array [],
+              "position": 1,
+              "status": "open",
+              "title": "One-Two-Two",
+            },
+          ],
+          "labels": Array [],
+          "position": 1,
+          "status": "open",
+          "title": "One-Two",
+        },
+        Object {
+          "children": Array [],
+          "labels": Array [],
+          "position": 2,
+          "status": "open",
+          "title": "One-Three",
+        },
+      ],
+      "labels": Array [],
+      "parentId": "id-0",
+      "position": 0,
+      "status": "open",
+      "title": "One",
+    },
+    "type": "ADD_TODO",
+  },
+  Object {
+    "data": Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "labels": Array [],
+          "position": 0,
+          "status": "open",
+          "title": "Two-One",
+        },
+        Object {
+          "children": Array [],
+          "labels": Array [],
+          "position": 1,
+          "status": "open",
+          "title": "Two-Two",
+        },
+      ],
+      "labels": Array [],
+      "parentId": "id-0",
+      "position": 1,
+      "status": "open",
+      "title": "Two",
+    },
+    "type": "ADD_TODO",
+  },
+  Object {
+    "data": Object {
+      "children": Array [],
+      "labels": Array [],
+      "parentId": "id-0",
+      "position": 2,
+      "status": "open",
+      "title": "Three",
+    },
+    "type": "ADD_TODO",
+  },
+  Object {
+    "data": Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "labels": Array [],
+          "position": 0,
+          "status": "open",
+          "title": "Four-One",
+        },
+        Object {
+          "children": Array [],
+          "labels": Array [],
+          "position": 1,
+          "status": "open",
+          "title": "Four-Two",
+        },
+      ],
+      "labels": Array [],
+      "parentId": "id-0",
+      "position": 3,
+      "status": "open",
+      "title": "Four",
+    },
+    "type": "ADD_TODO",
+  },
+]
+`;

--- a/packages/storage-events/src/__snapshots__/state-to-commands.spec.js.snap
+++ b/packages/storage-events/src/__snapshots__/state-to-commands.spec.js.snap
@@ -1,0 +1,117 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`stateToCommands returns working complex ADD_TODO commands 1`] = `
+Array [
+  Object {
+    "data": Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "labels": Array [],
+          "position": 0,
+          "status": "open",
+          "title": "One-One",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "labels": Array [],
+              "position": 0,
+              "status": "open",
+              "title": "One-Two-One",
+            },
+            Object {
+              "children": Array [],
+              "labels": Array [],
+              "position": 1,
+              "status": "open",
+              "title": "One-Two-Two",
+            },
+          ],
+          "labels": Array [],
+          "position": 1,
+          "status": "open",
+          "title": "One-Two",
+        },
+        Object {
+          "children": Array [],
+          "labels": Array [],
+          "position": 2,
+          "status": "open",
+          "title": "One-Three",
+        },
+      ],
+      "labels": Array [],
+      "parentId": null,
+      "position": 0,
+      "status": "open",
+      "title": "One",
+    },
+    "type": "ADD_TODO",
+  },
+  Object {
+    "data": Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "labels": Array [],
+          "position": 0,
+          "status": "open",
+          "title": "Two-One",
+        },
+        Object {
+          "children": Array [],
+          "labels": Array [],
+          "position": 1,
+          "status": "open",
+          "title": "Two-Two",
+        },
+      ],
+      "labels": Array [],
+      "parentId": null,
+      "position": 1,
+      "status": "open",
+      "title": "Two",
+    },
+    "type": "ADD_TODO",
+  },
+  Object {
+    "data": Object {
+      "children": Array [],
+      "labels": Array [],
+      "parentId": null,
+      "position": 2,
+      "status": "open",
+      "title": "Three",
+    },
+    "type": "ADD_TODO",
+  },
+  Object {
+    "data": Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "labels": Array [],
+          "position": 0,
+          "status": "open",
+          "title": "Four-One",
+        },
+        Object {
+          "children": Array [],
+          "labels": Array [],
+          "position": 1,
+          "status": "open",
+          "title": "Four-Two",
+        },
+      ],
+      "labels": Array [],
+      "parentId": null,
+      "position": 3,
+      "status": "open",
+      "title": "Four",
+    },
+    "type": "ADD_TODO",
+  },
+]
+`;

--- a/packages/storage-events/src/index.js
+++ b/packages/storage-events/src/index.js
@@ -1,5 +1,7 @@
 const replay = require("./replay.js");
+const stateToCommands = require("./state-to-commands.js");
 
 module.exports = {
-  replay
+  replay,
+  stateToCommands
 };

--- a/packages/storage-events/src/state-to-commands.js
+++ b/packages/storage-events/src/state-to-commands.js
@@ -1,7 +1,7 @@
 module.exports = stateToCommands;
 
-function stateToCommands(listOfTodos) {
-  return listOfTodos.map(todoToEvent(null));
+function stateToCommands(listOfTodos, parentId = null) {
+  return listOfTodos.map(todoToEvent(parentId));
 }
 
 const todoToEvent = parentId => todo => {

--- a/packages/storage-events/src/state-to-commands.js
+++ b/packages/storage-events/src/state-to-commands.js
@@ -5,12 +5,17 @@ function stateToCommands(listOfTodos) {
 }
 
 const todoToEvent = parentId => todo => {
-  const { todoId, ...rest } = todo;
+  const data = dataFromTodo(todo);
   return {
     type: "ADD_TODO",
-    data: {
-      ...rest,
-      parentId
-    }
+    data: { ...data, parentId }
+  };
+};
+
+const dataFromTodo = todo => {
+  const { todoId, children, ...rest } = todo;
+  return {
+    ...rest,
+    children: children.map(dataFromTodo)
   };
 };

--- a/packages/storage-events/src/state-to-commands.js
+++ b/packages/storage-events/src/state-to-commands.js
@@ -1,0 +1,16 @@
+module.exports = stateToCommands;
+
+function stateToCommands(listOfTodos) {
+  return listOfTodos.map(todoToEvent(null));
+}
+
+const todoToEvent = parentId => todo => {
+  const { todoId, ...rest } = todo;
+  return {
+    type: "ADD_TODO",
+    data: {
+      ...rest,
+      parentId
+    }
+  };
+};

--- a/packages/storage-events/src/state-to-commands.js
+++ b/packages/storage-events/src/state-to-commands.js
@@ -7,7 +7,7 @@ function stateToCommands(listOfTodos, parentId = null) {
 const todoToEvent = parentId => todo => {
   const data = dataFromTodo(todo);
   return {
-    type: "ADD_TODO",
+    command: "ADD_TODO",
     data: { ...data, parentId }
   };
 };

--- a/packages/storage-events/src/state-to-commands.spec.js
+++ b/packages/storage-events/src/state-to-commands.spec.js
@@ -65,4 +65,8 @@ describe("stateToCommands", () => {
   it("returns working complex ADD_TODO commands", () => {
     expect(stateToCommands(complexTest)).toMatchSnapshot();
   });
+
+  it("returns working complex ADD_TODO commands with parentId", () => {
+    expect(stateToCommands(complexTest, "id-0")).toMatchSnapshot();
+  });
 });

--- a/packages/storage-events/src/state-to-commands.spec.js
+++ b/packages/storage-events/src/state-to-commands.spec.js
@@ -1,0 +1,15 @@
+const stateToCommands = require("./state-to-commands.js");
+
+describe("stateToCommands", () => {
+  it("returns an empty list for empty state", () => {
+    expect(stateToCommands([])).toEqual([]);
+  });
+
+  it("returns a single ADDED_TODO for a single todo", () => {
+    // prettier-ignore
+    const myTodos = [ { children: [], todoId: "5bce72e9986417accf87547e-id-1-1-2", labels: [], position: 0, status: "open", title: "Test title" } ];
+    // prettier-ignore
+    const expected = [ { type: "ADD_TODO", data: { children: [], labels: [], parentId: null, position: 0, status: "open", title: "Test title" } } ];
+    expect(stateToCommands(myTodos)).toEqual(expected);
+  });
+});

--- a/packages/storage-events/src/state-to-commands.spec.js
+++ b/packages/storage-events/src/state-to-commands.spec.js
@@ -10,7 +10,7 @@ describe("stateToCommands", () => {
     const myTodos = [{ children: [], todoId: "1", labels: [], position: 0, status: "open", title: "Test title" }];
     const expected = [
       {
-        type: "ADD_TODO",
+        command: "ADD_TODO",
         data: { children: [], labels: [], parentId: null, position: 0, status: "open", title: "Test title" }
       }
     ];
@@ -24,11 +24,11 @@ describe("stateToCommands", () => {
     ];
     const expected = [
       {
-        type: "ADD_TODO",
+        command: "ADD_TODO",
         data: { children: [], labels: [], parentId: null, position: 0, status: "open", title: "One" }
       },
       {
-        type: "ADD_TODO",
+        command: "ADD_TODO",
         data: { children: [], labels: [], parentId: null, position: 1, status: "open", title: "Two" }
       }
     ];
@@ -48,7 +48,7 @@ describe("stateToCommands", () => {
     ];
     const expected = [
       {
-        type: "ADD_TODO",
+        command: "ADD_TODO",
         data: {
           children: [{ children: [], labels: [], position: 0, status: "open", title: "One-One" }],
           labels: [],

--- a/packages/storage-events/src/state-to-commands.spec.js
+++ b/packages/storage-events/src/state-to-commands.spec.js
@@ -1,3 +1,4 @@
+const complexTest = require("./__mocks__/state-to-commands-add-todo-complex.json");
 const stateToCommands = require("./state-to-commands.js");
 
 describe("stateToCommands", () => {
@@ -5,11 +6,63 @@ describe("stateToCommands", () => {
     expect(stateToCommands([])).toEqual([]);
   });
 
-  it("returns a single ADDED_TODO for a single todo", () => {
-    // prettier-ignore
-    const myTodos = [ { children: [], todoId: "5bce72e9986417accf87547e-id-1-1-2", labels: [], position: 0, status: "open", title: "Test title" } ];
-    // prettier-ignore
-    const expected = [ { type: "ADD_TODO", data: { children: [], labels: [], parentId: null, position: 0, status: "open", title: "Test title" } } ];
+  it("returns a single ADD_TODO for a single todo", () => {
+    const myTodos = [{ children: [], todoId: "1", labels: [], position: 0, status: "open", title: "Test title" }];
+    const expected = [
+      {
+        type: "ADD_TODO",
+        data: { children: [], labels: [], parentId: null, position: 0, status: "open", title: "Test title" }
+      }
+    ];
     expect(stateToCommands(myTodos)).toEqual(expected);
+  });
+
+  it("returns multiple ADD_TODO commands for multiple todos", () => {
+    const myTodos = [
+      { children: [], todoId: "1", labels: [], position: 0, status: "open", title: "One" },
+      { children: [], todoId: "2", labels: [], position: 1, status: "open", title: "Two" }
+    ];
+    const expected = [
+      {
+        type: "ADD_TODO",
+        data: { children: [], labels: [], parentId: null, position: 0, status: "open", title: "One" }
+      },
+      {
+        type: "ADD_TODO",
+        data: { children: [], labels: [], parentId: null, position: 1, status: "open", title: "Two" }
+      }
+    ];
+    expect(stateToCommands(myTodos)).toEqual(expected);
+  });
+
+  it("returns correct ADD_TODO commands for child todos", () => {
+    const myTodos = [
+      {
+        children: [{ children: [], todoId: "1-1", labels: [], position: 0, status: "open", title: "One-One" }],
+        todoId: "1",
+        labels: [],
+        position: 0,
+        status: "open",
+        title: "One"
+      }
+    ];
+    const expected = [
+      {
+        type: "ADD_TODO",
+        data: {
+          children: [{ children: [], labels: [], position: 0, status: "open", title: "One-One" }],
+          labels: [],
+          parentId: null,
+          position: 0,
+          status: "open",
+          title: "One"
+        }
+      }
+    ];
+    expect(stateToCommands(myTodos)).toEqual(expected);
+  });
+
+  it("returns working complex ADD_TODO commands", () => {
+    expect(stateToCommands(complexTest)).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
**Please check or ~strike-through~ all of the following**
This pull-request
- ~resolves NOT #141~
- [x] has a meaningful title
- ~contains a breaking change~
- [x] contains a new feature
- [x] complies to the [code of conduct](../blob/master/.github/CODE_OF_CONDUCT.md)
- ~installs new dependencies through `npm run bootstrap`~

**Changes**
- Dragging with `ALT` key into a dropzone copies todos now

**Implementation notes**
We need to wait for `Event.create` to finish to get the new ids. Thus, this may take a bit of time as it will need to communicate with MongoDB for every single added todo (= each sub-todo!). Maybe we could create temporary ids and replace them in the mongo layer somehow? It copies labels and tracked times as well. We should get rid of `trackedTimes` in Mongo.

This PR should pave the way for #141 as it adds logic to create `ADDED_TODO` events for a state.